### PR TITLE
Fix typo in jest setup

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,5 +4,5 @@ import '@testing-library/jest-dom'
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 process.env.VITE_API_URL = 'http://localhost:4000'
-process.env.VITE_WOMPI_PUBLIC_KEY = 'test_pusblic_key'
+process.env.VITE_WOMPI_PUBLIC_KEY = 'test_public_key'
 process.env.VITE_WOMPI_API_URL = 'https://sandbox.wompi.co/v1'


### PR DESCRIPTION
## Summary
- fix the WOMPI public key typo in jest setup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a9ebd3f883298514e3d2a4528f16