### PR TITLE
Add assertion for mocked product name

### DIFF
--- a/__tests__/ProductPage.test.tsx
+++ b/__tests__/ProductPage.test.tsx
@@ -26,5 +26,6 @@ describe('ProductPage', () => {
 
     expect(await screen.findByRole('heading', { name: /explora nuestros productos/i }))
       .toBeInTheDocument()
+    expect(await screen.findByText('Producto Test')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- verify that mocked product `Producto Test` is rendered in `ProductPage`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844abfca5708329ad771226f61fc30a